### PR TITLE
Implement Preline-inspired navigation and footer

### DIFF
--- a/kni_app/static_src/javascript/components/collapse.js
+++ b/kni_app/static_src/javascript/components/collapse.js
@@ -1,0 +1,116 @@
+class CollapseToggle {
+    static selector() {
+        return '[data-hs-collapse]';
+    }
+
+    constructor(node) {
+        this.toggle = node;
+        this.targetSelector = this.toggle.getAttribute('data-hs-collapse');
+        this.target = document.querySelector(this.targetSelector);
+        this.isTransitioning = false;
+
+        if (!this.target) {
+            return;
+        }
+
+        this.closeOnLinkClick = this.closeOnLinkClick.bind(this);
+        this.handleToggle = this.handleToggle.bind(this);
+        this.updateForViewport = this.updateForViewport.bind(this);
+
+        this.target.classList.add('hidden');
+        this.target.style.height = '0px';
+        this.toggle.setAttribute('aria-expanded', this.toggle.classList.contains('hs-collapse-open') ? 'true' : 'false');
+
+        this.toggle.addEventListener('click', this.handleToggle);
+        this.target.querySelectorAll('a').forEach((link) => {
+            link.addEventListener('click', this.closeOnLinkClick);
+        });
+
+        this.breakpoint = window.matchMedia('(min-width: 768px)');
+        if (this.breakpoint.addEventListener) {
+            this.breakpoint.addEventListener('change', this.updateForViewport);
+        } else if (this.breakpoint.addListener) {
+            this.breakpoint.addListener(this.updateForViewport);
+        }
+
+        this.updateForViewport(this.breakpoint);
+    }
+
+    handleToggle(event) {
+        event.preventDefault();
+
+        if (this.isTransitioning) {
+            return;
+        }
+
+        if (this.toggle.classList.contains('hs-collapse-open')) {
+            this.close();
+        } else {
+            this.open();
+        }
+    }
+
+    closeOnLinkClick() {
+        if (window.matchMedia('(max-width: 767px)').matches && this.toggle.classList.contains('hs-collapse-open')) {
+            this.close();
+        }
+    }
+
+    open() {
+        this.isTransitioning = true;
+        this.toggle.classList.add('hs-collapse-open');
+        this.toggle.setAttribute('data-hs-collapse-open', 'true');
+        this.toggle.setAttribute('aria-expanded', 'true');
+        this.target.classList.remove('hidden');
+        this.target.style.height = '0px';
+
+        requestAnimationFrame(() => {
+            this.target.style.height = this.target.scrollHeight + 'px';
+            this.target.classList.add('open');
+        });
+
+        this.target.addEventListener('transitionend', () => {
+            this.isTransitioning = false;
+            this.target.style.height = '';
+        }, { once: true });
+    }
+
+    close() {
+        this.isTransitioning = true;
+        this.toggle.classList.remove('hs-collapse-open');
+        this.toggle.removeAttribute('data-hs-collapse-open');
+        this.toggle.setAttribute('aria-expanded', 'false');
+
+        this.target.style.height = this.target.scrollHeight + 'px';
+        requestAnimationFrame(() => {
+            this.target.style.height = '0px';
+        });
+
+        this.target.addEventListener('transitionend', () => {
+            this.isTransitioning = false;
+            this.target.classList.remove('open');
+            this.target.classList.add('hidden');
+            this.target.style.height = '';
+        }, { once: true });
+    }
+
+    updateForViewport(event) {
+        const matches = typeof event.matches === 'boolean' ? event.matches : event;
+
+        if (matches) {
+            this.toggle.classList.add('hs-collapse-open');
+            this.toggle.setAttribute('data-hs-collapse-open', 'true');
+            this.toggle.setAttribute('aria-expanded', 'true');
+            this.target.classList.remove('hidden');
+            this.target.style.height = '';
+        } else {
+            this.toggle.classList.remove('hs-collapse-open');
+            this.toggle.removeAttribute('data-hs-collapse-open');
+            this.toggle.setAttribute('aria-expanded', 'false');
+            this.target.classList.add('hidden');
+            this.target.style.height = '0px';
+        }
+    }
+}
+
+export default CollapseToggle;

--- a/kni_app/static_src/javascript/main.js
+++ b/kni_app/static_src/javascript/main.js
@@ -1,7 +1,7 @@
 import ThemeToggle from "./components/theme-toggle";
 import HeaderSearchPanel from "./components/header-search-panel";
-import MobileMenu from "./components/mobile-menu";
 import SkipLink from './components/skip-link';
+import CollapseToggle from './components/collapse';
 
 import '../sass/main.scss';
 
@@ -13,8 +13,7 @@ function initComponent(ComponentClass) {
 
 document.addEventListener('DOMContentLoaded', () => {
     initComponent(ThemeToggle);
-    initComponent(ThemeToggle);
     initComponent(SkipLink);
     initComponent(HeaderSearchPanel);
-    initComponent(MobileMenu);
+    initComponent(CollapseToggle);
 });

--- a/kni_app/tailwind.config.js
+++ b/kni_app/tailwind.config.js
@@ -74,5 +74,8 @@ module.exports = {
                 'slash': `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='#26899E' viewBox='0 0 11 11'%3E%3Cpath d='M1.78239 10.8013L0.900391 9.99126L4.19439 6.60726L4.78839 7.14726L1.78239 10.8013ZM7.39839 4.33926L6.80439 3.79926L9.81039 0.145264L10.6924 0.955263L7.39839 4.33926Z' /%3E%3C/svg%3E");`
             },
         },
-    }
+    },
+    plugins: [
+        require('./tailwind.preline.js'),
+    ],
 };

--- a/kni_app/tailwind.preline.js
+++ b/kni_app/tailwind.preline.js
@@ -1,0 +1,9 @@
+const plugin = require('tailwindcss/plugin');
+
+module.exports = plugin(function({ addVariant, e }) {
+    addVariant('hs-collapse-open', ({ modifySelectors, separator }) => {
+        modifySelectors(({ className }) => {
+            return `.hs-collapse-open .${e(`hs-collapse-open${separator}${className}`)}`;
+        });
+    });
+});

--- a/kni_app/templates/components/search.html
+++ b/kni_app/templates/components/search.html
@@ -2,24 +2,16 @@
 <form action="{% url 'search' %}" method="get" role="search"
     class="
         {% if variant == 'search-panel' %}
-            site-container 
-            px-10 md:px-20
-            w-full
-            m-auto
-            flex
-            justify-end
+            mx-auto flex w-full max-w-3xl justify-center px-4
         {% elif variant == 'mobile-menu' %}
-            py-14
+            flex flex-col gap-4
         {% endif %}
     ">
-    <div 
+    <div
         class="
-        flex 
-        grow
-        {% if variant != 'mobile-menu' %}
-            flex-col 
-            md:flex-row
-            max-w-[520px]
+        flex w-full flex-col gap-3
+        {% if variant == 'search-panel' %}
+            md:flex-row md:items-center md:gap-4
         {% endif %}
         "
         {% if variant == "search-panel" %}
@@ -28,22 +20,11 @@
     >
         <input
             class="
+            w-full rounded-full border border-gray-200 px-5 py-3 text-base text-gray-700 placeholder:text-gray-400 focus:border-mackerel-300 focus:outline-none focus:ring-2 focus:ring-mackerel-300 focus:ring-offset-2 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500
             {% if variant == 'mobile-menu' %}
-            bg-white
-            bg-opacity-20
-            placeholder:text-white
-            text-white
-            dark:text-white
-            {% else %}
-                bg-white dark:bg-mackerel-100 
-                mb-3 md:mb-0
+                bg-white/80 text-gray-800 focus:ring-offset-0 dark:bg-gray-800 dark:text-gray-100
             {% endif %}
-            border border-mackerel-200 
-            placeholder:text-base text-base 
-            w-full h-[50px] 
-            rounded-[30px] 
-            px-4 pt-3 pb-2 mr-3
-            " 
+            "
             type="search"
             aria-label="Search our website"
             placeholder="Search our website"
@@ -52,26 +33,11 @@
                 data-search-input
             {% endif %}
         />
-        <button 
-            class="
+        <button
+            class="inline-flex items-center justify-center rounded-full bg-mackerel-300 px-6 py-3 text-sm font-semibold uppercase tracking-wide text-white transition hover:bg-mackerel-200 focus:outline-none focus:ring-2 focus:ring-mackerel-300 focus:ring-offset-2 dark:text-gray-900
             {% if variant == 'mobile-menu' %}
-            text-white 
-            bg-mackerel-400
-            {% else %}
-                text-white 
-                dark:text-mackerel-400 
-                bg-mackerel-300 
+                md:self-start
             {% endif %}
-            px-5 
-            py-3 
-            justify-center 
-            items-center 
-            text-sm 
-            md:text-base 
-            font-codepro 
-            uppercase 
-            inline-flex 
-            rounded-[30px]
             "
         >
             Search

--- a/kni_app/templates/navigation/footer.html
+++ b/kni_app/templates/navigation/footer.html
@@ -2,122 +2,125 @@
 {% load wagtailcore_tags wagtailsettings_tags static %}
 {% wagtail_site as current_site %}
 
-
-<div class="px-4">
-    <div class="bg-slash opacity-50 h-4 w-full"></div>
-</div>
-
-<footer class="site-padding site-container w-full py-20">
-    <div class="flex flex-col lg:flex-row gap-20 justify-between">
-        {% if settings.navigation.NavigationSettings.footer_navigation %}
-        <div class="grid grid-cols-2 gap-20 justify-between">
-            {% for link_section in settings.navigation.NavigationSettings.footer_navigation %}
-                <div class="mb-10 lg:mb-0 lg:mr-20 flex flex-col gap-10">
-                    <h2 class="text-xl md:text-2xl font-semibold">
-                        {{ link_section.value.section_heading }}
-                    </h2>
-                    <ul class="flex flex-col gap-y-4 md:gap-y-6">
-                        {% for link in link_section.value.links %}
-                        <li>
-                            <a href="{{ link.value.get_url }}"
-                                class="
-                                text-grey-700
-                                dark:text-grey-200
-                                underline
-                                underline-offset-8
-                                decoration-[1.5px]
-                                decoration-mackerel-200
-                                hover:decoration-mackerel-300
-                                ">
-                                {{ link.value.get_title }}
-                            </a>
-                        </li>
-                        {% endfor %}
-                    </ul>
+<footer id="site-footer" class="border-t border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900" aria-labelledby="site-footer">
+    <div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
+        <div class="flex flex-col gap-16 lg:grid lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)] lg:items-start">
+            {% if settings.navigation.NavigationSettings.footer_navigation %}
+                <div class="grid gap-12 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                    {% for link_section in settings.navigation.NavigationSettings.footer_navigation %}
+                        <div>
+                            <h2 class="text-sm font-semibold uppercase tracking-widest text-gray-500 dark:text-gray-400">
+                                {{ link_section.value.section_heading }}
+                            </h2>
+                            <ul class="mt-6 space-y-3">
+                                {% for link in link_section.value.links %}
+                                    <li>
+                                        <a
+                                            href="{{ link.value.get_url }}"
+                                            class="text-base text-gray-600 transition hover:text-mackerel-300 focus:outline-none focus:ring-2 focus:ring-mackerel-300 focus:ring-offset-2 dark:text-gray-300 dark:hover:text-white"
+                                        >
+                                            {{ link.value.get_title }}
+                                        </a>
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        </div>
+                    {% endfor %}
                 </div>
-            {% endfor %}
-        </div>
-        {% endif %}
+            {% endif %}
 
-        <div>
-            {% if settings.utils.SystemMessagesSettings.footer_newsletter_signup_link %}
-                <div class="flex flex-col max-w-96">
-                    <h2 
-                        class="text-xl md:text-2xl font-semibold"
-                        id="footer-newsletter-signup-title"
-                    >
-                        {{ settings.utils.SystemMessagesSettings.footer_newsletter_signup_title }}
-                    </h2>
-                    {% if settings.utils.SystemMessagesSettings.footer_newsletter_signup_description %}
-                    <p class="pt-3 text-base md:text-lg text-grey-700 dark:text-grey-200 md:leading-[170%]">
-                        {{ settings.utils.SystemMessagesSettings.footer_newsletter_signup_description }}
-                    </p>
-                    {% endif %}
-                    <div class="pt-5 flex gap-1 md:gap-2.5">
-                        <input 
-                            type="email" 
-                            placeholder="Enter your email" 
-                            aria-labelledby="footer-newsletter-signup-title"
-                            class="border-[1px] border-mackerel-200 rounded-[3px] px-5 md:py-2.5 md:px-5 text-base md:text-lg bg-white dark:bg-mackerel-100 dark:text-white">
-                        {% include "components/button.html" with variant="footer" title="Sign up" url=settings.utils.SystemMessagesSettings.footer_newsletter_signup_link %}
+            <div class="flex w-full flex-col gap-10 rounded-2xl border border-gray-200 p-6 shadow-sm dark:border-gray-700 dark:bg-gray-900/60">
+                {% if settings.utils.SystemMessagesSettings.footer_newsletter_signup_link %}
+                    <div class="flex flex-col gap-4">
+                        <h2
+                            class="text-xl font-semibold text-gray-900 dark:text-white"
+                            id="footer-newsletter-signup-title"
+                        >
+                            {{ settings.utils.SystemMessagesSettings.footer_newsletter_signup_title }}
+                        </h2>
+                        {% if settings.utils.SystemMessagesSettings.footer_newsletter_signup_description %}
+                            <p class="text-base leading-relaxed text-gray-600 dark:text-gray-300">
+                                {{ settings.utils.SystemMessagesSettings.footer_newsletter_signup_description }}
+                            </p>
+                        {% endif %}
+                        <div class="flex flex-col gap-3 sm:flex-row">
+                            <input
+                                type="email"
+                                placeholder="Enter your email"
+                                aria-labelledby="footer-newsletter-signup-title"
+                                class="h-12 flex-1 rounded-full border border-gray-200 px-5 text-base text-gray-700 focus:border-mackerel-300 focus:outline-none focus:ring-2 focus:ring-mackerel-300 focus:ring-offset-2 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
+                            >
+                            {% include "components/button.html" with variant="footer" title="Sign up" url=settings.utils.SystemMessagesSettings.footer_newsletter_signup_link classes="w-full sm:w-auto" %}
+                        </div>
                     </div>
-                </div>
-            {% endif %}
+                {% endif %}
 
-            {% if settings.utils.SocialMediaSettings.linkedin_handle or settings.utils.SocialMediaSettings.facebook_app_id or settings.utils.SocialMediaSettings.instagram_handle or settings.utils.SocialMediaSettings.tiktok_handle %}
-                <p class="sr-only">Follow us</p>
-                <div class="flex flex-row gap-10 pt-14">
-                    {% if settings.utils.SocialMediaSettings.linkedin_handle %}
-                    <a href="https://linkedin.com/company/{{ settings.utils.SocialMediaSettings.linkedin_handle }}"
-                        aria-label="{{ current_site.site_name|default:'We&apos;re' }} on LinkedIn"
-                        class="hover:text-mackerel-300">
-                        <svg aria-hidden="true" class="fill-current w-7 h-7" width="30" height="31" viewBox="0 0 30 31" fill="none" xmlns="http://www.w3.org/2000/svg">
-                            <path d="M27.8571 0.376953H2.13616C0.957589 0.376953 0 1.34794 0 2.5399V28.214C0 29.406 0.957589 30.377 2.13616 30.377H27.8571C29.0357 30.377 30 29.406 30 28.214V2.5399C30 1.34794 29.0357 0.376953 27.8571 0.376953ZM9.06696 26.0912H4.62054V11.7743H9.07366V26.0912H9.06696ZM6.84375 9.81892C5.41741 9.81892 4.26562 8.66044 4.26562 7.24079C4.26562 5.82115 5.41741 4.66267 6.84375 4.66267C8.26339 4.66267 9.42188 5.82115 9.42188 7.24079C9.42188 8.66713 8.27009 9.81892 6.84375 9.81892ZM25.7344 26.0912H21.2879V19.127C21.2879 17.4662 21.2545 15.3301 18.9777 15.3301C16.6607 15.3301 16.3058 17.1381 16.3058 19.0064V26.0912H11.8594V11.7743H16.125V13.7296H16.1853C16.7812 12.6046 18.2344 11.4194 20.3973 11.4194C24.8973 11.4194 25.7344 14.3859 25.7344 18.243V26.0912Z"/>
-                        </svg>
-                    </a>
-                    {% endif %}
-                    {% if settings.utils.SocialMediaSettings.instagram_handle %}
-                    <a href="https://www.instagram.com/{{ settings.utils.SocialMediaSettings.instagram_handle }}"
-                        aria-label="{{ current_site.site_name|default:'We&apos;re' }} on Instagram"
-                        class="hover:text-mackerel-300">
-                        <svg aria-hidden="true" class="fill-current w-7 h-7" width="30" height="31" viewBox="0 0 30 31" fill="none" xmlns="http://www.w3.org/2000/svg">
-                            <path d="M15.0033 7.68533C10.7468 7.68533 7.31344 11.1194 7.31344 15.377C7.31344 19.6345 10.7468 23.0686 15.0033 23.0686C19.2599 23.0686 22.6933 19.6345 22.6933 15.377C22.6933 11.1194 19.2599 7.68533 15.0033 7.68533ZM15.0033 20.3775C12.2527 20.3775 10.0039 18.135 10.0039 15.377C10.0039 12.6189 12.246 10.3764 15.0033 10.3764C17.7607 10.3764 20.0028 12.6189 20.0028 15.377C20.0028 18.135 17.754 20.3775 15.0033 20.3775ZM24.8015 7.37071C24.8015 8.36814 23.9983 9.16475 23.0078 9.16475C22.0106 9.16475 21.2142 8.36144 21.2142 7.37071C21.2142 6.37997 22.0173 5.57666 23.0078 5.57666C23.9983 5.57666 24.8015 6.37997 24.8015 7.37071ZM29.8946 9.19152C29.7808 6.78831 29.232 4.65956 27.4718 2.90568C25.7184 1.15181 23.5901 0.602882 21.1874 0.482387C18.7111 0.341809 11.2889 0.341809 8.8126 0.482387C6.41662 0.596188 4.28834 1.14511 2.52817 2.89899C0.767987 4.65287 0.225878 6.78162 0.10541 9.18483C-0.0351366 11.6617 -0.0351366 19.0855 0.10541 21.5624C0.219186 23.9656 0.767987 26.0943 2.52817 27.8482C4.28834 29.6021 6.40993 30.151 8.8126 30.2715C11.2889 30.4121 18.7111 30.4121 21.1874 30.2715C23.5901 30.1577 25.7184 29.6088 27.4718 27.8482C29.2253 26.0943 29.7741 23.9656 29.8946 21.5624C30.0351 19.0855 30.0351 11.6684 29.8946 9.19152ZM26.6955 24.22C26.1735 25.532 25.1629 26.5429 23.8444 27.0717C21.8701 27.8549 17.1852 27.6742 15.0033 27.6742C12.8215 27.6742 8.12995 27.8482 6.1623 27.0717C4.85053 26.5496 3.83993 25.5387 3.31121 24.22C2.52817 22.2452 2.70887 17.5593 2.70887 15.377C2.70887 13.1946 2.53486 8.50202 3.31121 6.53393C3.83324 5.22187 4.84384 4.21105 6.1623 3.68221C8.13664 2.89899 12.8215 3.07973 15.0033 3.07973C17.1852 3.07973 21.8767 2.90568 23.8444 3.68221C25.1562 4.20435 26.1668 5.21518 26.6955 6.53393C27.4785 8.50872 27.2978 13.1946 27.2978 15.377C27.2978 17.5593 27.4785 22.2519 26.6955 24.22Z"/>
-                        </svg>
-                    </a>
-                    {% endif %}
-                    {% if settings.utils.SocialMediaSettings.twitter_handle %}
-                    <a href="https://twitter.com/{{ settings.utils.SocialMediaSettings.twitter_handle }}"
-                        aria-label="{{ current_site.site_name|default:'We&apos;re' }} on Twitter"
-                        class="hover:text-mackerel-300">
-                        <svg aria-hidden="true" class="fill-current w-7 h-7" viewBox="0 0 34 31">
-                            <path d="M26.1346 0.376953H31.226L20.1058 13.0837L33.1875 30.377H22.9471L14.9207 19.8914L5.7476 30.377H0.649038L12.5409 16.7832L0 0.376953H10.5L17.7476 9.96109L26.1346 0.376953ZM24.3462 27.3337H27.1659L8.96394 3.26157H5.9351L24.3462 27.3337Z"/>
-                        </svg>
-                    </a>
-                    {% endif %}
-                    {% if settings.utils.SocialMediaSettings.tiktok_handle %}
-                    <a href="https://www.tiktok.com/@{{ settings.utils.SocialMediaSettings.tiktok_handle }}"
-                        aria-label="{{ current_site.site_name|default:'We&apos;re' }} on TikTok"
-                        class="hover:text-mackerel-300">
-                        <svg aria-hidden="true" class="fill-current w-7 h-7" viewBox="0 0 27 31">
-                            <path d="m26.5319 12.677c-2.5808.0055-5.098-.8001-7.196-2.303v10.4776c-.0006 1.9405-.5937 3.8346-1.6999 5.4289-1.1063 1.5943-2.6729 2.8128-4.4904 3.4926-1.8176.6798-3.79933.7885-5.68028.3115-1.88096-.477-3.57143-1.517-4.84533-2.9808s-2.070494-3.2817-2.283245-5.2105.168484-3.8766 1.092715-5.5828c.92424-1.7063 2.34741-3.0897 4.07918-3.9652s3.68957-1.2014 5.61156-.9341v5.2681c-.8788-.2766-1.8226-.2685-2.69657.0232-.87396.2916-1.63342.852-2.16994 1.601-.53651.7491-.82265 1.6485-.81756 2.5698s.30116 1.8175.84592 2.5606c.54477.743 1.31038 1.2949 2.18751 1.577.87713.282 1.82094.2796 2.69664-.0067.8758-.2864 1.6386-.8421 2.1797-1.5879.5411-.7457.8327-1.6433.8332-2.5647v-20.474647h5.1568c-.0029.436135.0343.871607.1113 1.300907.1793.95693.5519 1.86724 1.095 2.6753s1.2452 1.49688 2.0635 2.02438c1.1648.76932 2.5302 1.17895 3.9262 1.17785z" />
-                        </svg>
-                    </a>
-                    {% endif %}
-                    {% if settings.utils.SocialMediaSettings.facebook_app_id %}
-                    <a href="https://www.facebook.com/{{ settings.utils.SocialMediaSettings.facebook_app_id }}"
-                        aria-label="{{ current_site.site_name|default:'We&apos;re' }} on Facebook"
-                        class="hover:text-mackerel-300">
-                        <svg aria-hidden="true" class="fill-current w-7 h-7" viewBox="0 0 18 31">
-                            <path d="m4.05469 17.9141v12.4629h6.79691v-12.4629h5.0683l1.0547-5.7305h-6.123v-2.0274c0-3.02925 1.1894-4.1894 4.2597-4.1894.9551 0 1.7227.02343 2.168.07031v-5.197266c-.8379-.228516-2.8887-.462891-4.0723-.462891-6.26364 0-9.15231 2.958987-9.15231 9.339847v2.4668h-3.86719v5.7305z" />
-                        </svg>
-                    </a>
-                    {% endif %}
-                </div>
-            {% endif %}
+                {% if settings.utils.SocialMediaSettings.linkedin_handle or settings.utils.SocialMediaSettings.facebook_app_id or settings.utils.SocialMediaSettings.instagram_handle or settings.utils.SocialMediaSettings.tiktok_handle or settings.utils.SocialMediaSettings.twitter_handle %}
+                    <div class="flex flex-col gap-4">
+                        <p class="text-sm font-semibold uppercase tracking-widest text-gray-500 dark:text-gray-400">Follow us</p>
+                        <div class="flex flex-wrap items-center gap-5">
+                            {% if settings.utils.SocialMediaSettings.linkedin_handle %}
+                                <a href="https://linkedin.com/company/{{ settings.utils.SocialMediaSettings.linkedin_handle }}"
+                                    aria-label="{{ current_site.site_name|default:'We&apos;re' }} on LinkedIn"
+                                    class="text-gray-500 transition hover:text-mackerel-300 focus:outline-none focus:ring-2 focus:ring-mackerel-300 focus:ring-offset-2 dark:text-gray-400 dark:hover:text-white"
+                                >
+                                    <svg aria-hidden="true" class="h-6 w-6" viewBox="0 0 30 31" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                                        <path d="M27.8571 0.376953H2.13616C0.957589 0.376953 0 1.34794 0 2.5399V28.214C0 29.406 0.957589 30.377 2.13616 30.377H27.8571C29.0357 30.377 30 29.406 30 28.214V2.5399C30 1.34794 29.0357 0.376953 27.8571 0.376953ZM9.06696 26.0912H4.62054V11.7743H9.07366V26.0912H9.06696ZM6.84375 9.81892C5.41741 9.81892 4.26562 8.66044 4.26562 7.24079C4.26562 5.82115 5.41741 4.66267 6.84375 4.66267C8.26339 4.66267 9.42188 5.82115 9.42188 7.24079C9.42188 8.66713 8.27009 9.81892 6.84375 9.81892ZM25.7344 26.0912H21.2879V19.127C21.2879 17.4662 21.2545 15.3301 18.9777 15.3301C16.6607 15.3301 16.3058 17.1381 16.3058 19.0064V26.0912H11.8594V11.7743H16.125V13.7296H16.1853C16.7812 12.6046 18.2344 11.4194 20.3973 11.4194C24.8973 11.4194 25.7344 14.3859 25.7344 18.243V26.0912Z"/>
+                                    </svg>
+                                </a>
+                            {% endif %}
+                            {% if settings.utils.SocialMediaSettings.instagram_handle %}
+                                <a href="https://www.instagram.com/{{ settings.utils.SocialMediaSettings.instagram_handle }}"
+                                    aria-label="{{ current_site.site_name|default:'We&apos;re' }} on Instagram"
+                                    class="text-gray-500 transition hover:text-mackerel-300 focus:outline-none focus:ring-2 focus:ring-mackerel-300 focus:ring-offset-2 dark:text-gray-400 dark:hover:text-white"
+                                >
+                                    <svg aria-hidden="true" class="h-6 w-6" viewBox="0 0 30 31" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                                        <path d="M15.0033 7.68533C10.7468 7.68533 7.31344 11.1194 7.31344 15.377C7.31344 19.6345 10.7468 23.0686 15.0033 23.0686C19.2599 23.0686 22.6933 19.6345 22.6933 15.377C22.6933 11.1194 19.2599 7.68533 15.0033 7.68533ZM15.0033 20.3775C12.2527 20.3775 10.0039 18.135 10.0039 15.377C10.0039 12.6189 12.246 10.3764 15.0033 10.3764C17.7607 10.3764 20.0028 12.6189 20.0028 15.377C20.0028 18.135 17.754 20.3775 15.0033 20.3775ZM24.8015 7.37071C24.8015 8.36814 23.9983 9.16475 23.0078 9.16475C22.0106 9.16475 21.2142 8.36144 21.2142 7.37071C21.2142 6.37997 22.0173 5.57666 23.0078 5.57666C23.9983 5.57666 24.8015 6.37997 24.8015 7.37071ZM29.8946 9.19152C29.7808 6.78831 29.232 4.65956 27.4718 2.90568C25.7184 1.15181 23.5901 0.602882 21.1874 0.482387C18.7111 0.341809 11.2889 0.341809 8.8126 0.482387C6.41662 0.596188 4.28834 1.14511 2.52817 2.89899C0.767987 4.65287 0.225878 6.78162 0.10541 9.18483C-0.0351366 11.6617 -0.0351366 19.0855 0.10541 21.5624C0.219186 23.9656 0.767987 26.0943 2.52817 27.8482C4.28834 29.6021 6.40993 30.151 8.8126 30.2715C11.2889 30.4121 18.7111 30.4121 21.1874 30.2715C23.5901 30.1577 25.7184 29.6088 27.4718 27.8482C29.2253 26.0943 29.7741 23.9656 29.8946 21.5624C30.0351 19.0855 30.0351 11.6684 29.8946 9.19152ZM26.6955 24.22C26.1735 25.532 25.1629 26.5429 23.8444 27.0717C21.8701 27.8549 17.1852 27.6742 15.0033 27.6742C12.8215 27.6742 8.12995 27.8482 6.1623 27.0717C4.85053 26.5496 3.83993 25.5387 3.31121 24.22C2.52817 22.2452 2.70887 17.5593 2.70887 15.377C2.70887 13.1946 2.53486 8.50202 3.31121 6.53393C3.83324 5.22187 4.84384 4.21105 6.1623 3.68221C8.13664 2.89899 12.8215 3.07973 15.0033 3.07973C17.1852 3.07973 21.8767 2.90568 23.8444 3.68221C25.1562 4.20435 26.1668 5.21518 26.6955 6.53393C27.4785 8.50872 27.2978 13.1946 27.2978 15.377C27.2978 17.5593 27.4785 22.2519 26.6955 24.22Z"/>
+                                    </svg>
+                                </a>
+                            {% endif %}
+                            {% if settings.utils.SocialMediaSettings.twitter_handle %}
+                                <a href="https://twitter.com/{{ settings.utils.SocialMediaSettings.twitter_handle }}"
+                                    aria-label="{{ current_site.site_name|default:'We&apos;re' }} on Twitter"
+                                    class="text-gray-500 transition hover:text-mackerel-300 focus:outline-none focus:ring-2 focus:ring-mackerel-300 focus:ring-offset-2 dark:text-gray-400 dark:hover:text-white"
+                                >
+                                    <svg aria-hidden="true" class="h-6 w-6" viewBox="0 0 34 31" fill="currentColor">
+                                        <path d="M26.1346 0.376953H31.226L20.1058 13.0837L33.1875 30.377H22.9471L14.9207 19.8914L5.7476 30.377H0.649038L12.5409 16.7832L0 0.376953H10.5L17.7476 9.96109L26.1346 0.376953ZM24.3462 27.3337H27.1659L8.96394 3.26157H5.9351L24.3462 27.3337Z"/>
+                                    </svg>
+                                </a>
+                            {% endif %}
+                            {% if settings.utils.SocialMediaSettings.tiktok_handle %}
+                                <a href="https://www.tiktok.com/@{{ settings.utils.SocialMediaSettings.tiktok_handle }}"
+                                    aria-label="{{ current_site.site_name|default:'We&apos;re' }} on TikTok"
+                                    class="text-gray-500 transition hover:text-mackerel-300 focus:outline-none focus:ring-2 focus:ring-mackerel-300 focus:ring-offset-2 dark:text-gray-400 dark:hover:text-white"
+                                >
+                                    <svg aria-hidden="true" class="h-6 w-6" viewBox="0 0 27 31" fill="currentColor">
+                                        <path d="m26.5319 12.677c-2.5808.0055-5.098-.8001-7.196-2.303v10.4776c-.0006 1.9405-.5937 3.8346-1.6999 5.4289-1.1063 1.5943-2.6729 2.8128-4.4904 3.4926-1.8176.6798-3.79933.7885-5.68028.3115-1.88096-.477-3.57143-1.517-4.84533-2.9808s-2.070494-3.2817-2.283245-5.2105.168484-3.8766 1.092715-5.5828c.92424-1.7063 2.34741-3.0897 4.07918-3.9652s3.68957-1.2014 5.61156-.9341v5.2681c-.8788-.2766-1.8226-.2685-2.69657.0232-.87396.2916-1.63342.852-2.16994 1.601-.53651.7491-.82265 1.6485-.81756 2.5698s.30116 1.8175.84592 2.5606c.54477.743 1.31038 1.2949 2.18751 1.577.87713.282 1.82094.2796 2.69664-.0067.8758-.2864 1.6386-.8421 2.1797-1.5879.5411-.7457.8327-1.6433.8332-2.5647v-20.474647h5.1568c-.0029.436135.0343.871607.1113 1.300907.1793.95693.5519 1.86724 1.095 2.6753s1.2452 1.49688 2.0635 2.02438c1.1648.76932 2.5302 1.17895 3.9262 1.17785z" />
+                                    </svg>
+                                </a>
+                            {% endif %}
+                            {% if settings.utils.SocialMediaSettings.facebook_app_id %}
+                                <a href="https://www.facebook.com/{{ settings.utils.SocialMediaSettings.facebook_app_id }}"
+                                    aria-label="{{ current_site.site_name|default:'We&apos;re' }} on Facebook"
+                                    class="text-gray-500 transition hover:text-mackerel-300 focus:outline-none focus:ring-2 focus:ring-mackerel-300 focus:ring-offset-2 dark:text-gray-400 dark:hover:text-white"
+                                >
+                                    <svg aria-hidden="true" class="h-6 w-6" viewBox="0 0 18 31" fill="currentColor">
+                                        <path d="m4.05469 17.9141v12.4629h6.79691v-12.4629h5.0683l1.0547-5.7305h-6.123v-2.0274c0-3.02925 1.1894-4.1894 4.2597-4.1894.9551 0 1.7227.02343 2.168.07031v-5.197266c-.8379-.228516-2.8887-.462891-4.0723-.462891-6.26364 0-9.15231 2.958987-9.15231 9.339847v2.4668h-3.86719v5.7305z" />
+                                    </svg>
+                                </a>
+                            {% endif %}
+                        </div>
+                    </div>
+                {% endif %}
+            </div>
+        </div>
+
+        <div class="mt-16 border-t border-gray-200 pt-8 dark:border-gray-700">
+            <div class="flex flex-col gap-4 text-sm text-gray-500 dark:text-gray-400 sm:flex-row sm:items-center sm:justify-between">
+                <p>© {% now "Y" %} {{ current_site.site_name|default:"Wagtail Starter Kit" }}</p>
+                <p class="text-xs uppercase tracking-[0.3em] text-gray-400 dark:text-gray-500">Crafted with Wagtail &amp; Preline UI</p>
+            </div>
         </div>
     </div>
-    <p class="font-codepro text-base text-black dark:text-white opacity-60 pt-10 md:pt-20 mb-10 leading-6">
-        © {% now "Y" %} Wagtail Starter Kit
-    </p>
 </footer>
 

--- a/kni_app/templates/navigation/header.html
+++ b/kni_app/templates/navigation/header.html
@@ -2,158 +2,88 @@
 {% load wagtailcore_tags wagtailsettings_tags %}
 {% wagtail_site as current_site %}
 
-
-<header class="site-container w-full px-10 pt-14 pb-8 md:py-8 md:px-20">
-    <div class="flex justify-between items-center ">
-        <a 
+<header class="sticky top-0 z-40 w-full border-b border-gray-200 bg-white/90 backdrop-blur-md transition dark:border-gray-700 dark:bg-gray-900/90">
+    <div class="mx-auto flex max-w-7xl flex-wrap items-center gap-x-6 gap-y-4 px-4 py-4 sm:px-6 lg:px-8">
+        <a
             href="/"
             data-header-logo
-            class="header-logo z-30 uppercase font-semibold text-3xl"
+            class="flex items-center text-xl font-semibold uppercase tracking-wide text-gray-900 transition hover:text-mackerel-300 focus:outline-none focus:ring-2 focus:ring-mackerel-300 focus:ring-offset-2 dark:text-white"
             aria-label="Go to the Wagtail Starter Kit homepage">
             {{ current_site.site_name|default:"Site name" }}
         </a>
 
-        
-        <div class="flex md:hidden items-center gap-4">
-            <button 
-                class="z-30 button-menu-toggle" 
-                data-mobile-menu-toggle
-                aria-haspopup="true" 
-                aria-expanded="false" 
-                aria-label="Open navigation menu"
+        <div class="ml-auto flex items-center gap-x-3 md:order-3 md:ml-0 md:hidden">
+            <button
+                type="button"
+                class="inline-flex items-center justify-center rounded-lg border border-gray-200 p-2 text-sm font-medium text-gray-700 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-mackerel-300 focus:ring-offset-2 dark:border-gray-700 dark:text-gray-300 dark:hover:text-gray-100"
+                data-hs-collapse="#main-navigation"
+                aria-controls="main-navigation"
+                aria-expanded="false"
+                aria-label="Toggle navigation"
             >
-                <span class="button-menu-toggle__line"></span>
-                <span class="button-menu-toggle__line"></span>
+                <svg class="h-5 w-5 hs-collapse-open:hidden" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+                </svg>
+                <svg class="hidden h-5 w-5 hs-collapse-open:block" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
                 <span class="sr-only">Menu</span>
             </button>
         </div>
-        
-        
-        <nav aria-label="Primary" class="hidden md:block">
-            <ul class="flex gap-x-12 lg:gap-x-14">
-                {% for link in settings.navigation.NavigationSettings.primary_navigation %}
-                    <li>
-                        {% if link.value.page %}
-                            <a 
-                                class="
-                                flex 
-                                text-base 
-                                items-center 
-                                font-semibold 
-                                font-codepro
-                                underline
-                                underline-offset-8
-                                decoration-[1.5px]
-                                decoration-mackerel-200
-                                hover:decoration-mackerel-300
-                                " 
-                                href="{{ link.value.get_url }}" 
-                            >
-                                {{ link.value.get_title }}
-                            </a>
-                        {% endif %}
-                    </li>
-                {% endfor %}
-                <li class="flex items-center">
-                    <button 
+
+        <div
+            id="main-navigation"
+            class="hs-collapse hidden w-full basis-full grow overflow-hidden transition-[height] duration-300 ease-in-out md:order-2 md:block md:basis-auto"
+        >
+            <div class="flex flex-col gap-6 border-t border-gray-200 pt-6 dark:border-gray-700 md:flex-row md:items-center md:justify-between md:gap-8 md:border-0 md:pt-0">
+                <nav aria-label="Primary" class="w-full md:w-auto">
+                    <ul class="flex flex-col gap-5 md:flex-row md:items-center md:gap-8">
+                        {% for link in settings.navigation.NavigationSettings.primary_navigation %}
+                            {% if link.value.page %}
+                                <li data-desktop-nav-item>
+                                    <a
+                                        href="{{ link.value.get_url }}"
+                                        class="text-base font-medium text-gray-700 transition hover:text-mackerel-300 focus:outline-none focus:ring-2 focus:ring-mackerel-300 focus:ring-offset-2 dark:text-gray-200 dark:hover:text-white"
+                                    >
+                                        {{ link.value.get_title }}
+                                    </a>
+                                </li>
+                            {% endif %}
+                        {% endfor %}
+                    </ul>
+                </nav>
+
+                <div class="flex w-full flex-col gap-6 md:hidden">
+                    {% include "components/search.html" with variant="mobile-menu" %}
+                    <div class="flex justify-start">
+                        {% include "components/theme-toggle.html" %}
+                    </div>
+                </div>
+
+                <div class="hidden items-center gap-x-4 md:flex">
+                    <button
                         data-toggle-search-panel
                         type="button"
-                        aria-expanded="true" 
-                        aria-controls="search-panel" 
-                        aria-label="Show search overlay" 
-                        class=""
-                        >
-                        <span class="sr-only">
-                        Search 
-                        </span>
-                        {% include "icons/magnifying-glass.html" with class="fill-current w-5 h-5" %}
+                        aria-expanded="false"
+                        aria-controls="search-panel"
+                        aria-label="Show search overlay"
+                        class="flex h-11 w-11 items-center justify-center rounded-full border border-gray-200 text-gray-600 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-mackerel-300 focus:ring-offset-2 dark:border-gray-700 dark:text-gray-300 dark:hover:text-gray-100"
+                    >
+                        <span class="sr-only">Search</span>
+                        {% include "icons/magnifying-glass.html" with class="h-5 w-5" %}
                     </button>
-                </li>
-                <li>
                     {% include "components/theme-toggle.html" %}
-                </li>
-            </ul>
-        </nav>
-    </div>
+                </div>
+            </div>
+        </div>
 
-    
-    <section 
-        class="
-        md:hidden 
-        invisible 
-        transition-all 
-        duration-[640ms] 
-        ease-out-expo 
-        translate-x-full 
-        h-screen 
-        w-full
-        fixed 
-        top-0
-        left-0 
-        z-20
-        bg-mackerel-300
-        px-10 md:px-20
-        " 
-        data-mobile-menu-content
-    >
-    <nav aria-label="Primary" class="py-32">
-        <ul class="flex flex-col pt-5">
-            {% for link in settings.navigation.NavigationSettings.primary_navigation %}
-                <li class="
-                    border-t-[1px]
-                    border-dashed
-                    border-mackerel-200
-                    last-of-type:border-b-[1px]
-                ">
-                    {% if link.value.page %}
-                        <a 
-                            class="
-                            flex
-                            py-6
-                            text-lg
-                            items-center 
-                            font-semibold 
-                            font-codepro
-                            underline
-                            underline-offset-8
-                            text-white
-                            decoration-transparent
-                            hover:decoration-white
-                            decoration-[1.5px]
-                            " 
-                            href="" 
-                        >
-                             {{ link.value.get_title }}
-                        </a>
-                    {% endif %}
-                </li>
-            {% endfor %}
-        </ul>
-        {% include "components/search.html" with variant="mobile-menu" %}
-        {% include "components/theme-toggle.html" %}
-    </nav>
-    </section>
-
-    
-    <div 
-        id="search-panel"
-        data-search-panel
-        class="
-        z-10
-        absolute
-        hidden
-        md:block
-        invisible
-        top-0
-        right-0
-        pt-24
-        w-full
-        h-full 
-        bg-black
-        bg-opacity-20
-        "
-    >
-        {% include "components/search.html" with variant="search-panel" %}
+        <div
+            id="search-panel"
+            data-search-panel
+            class="invisible absolute inset-0 hidden min-h-full w-full bg-gray-900/70 backdrop-blur-sm transition md:flex"
+        >
+            {% include "components/search.html" with variant="search-panel" %}
+        </div>
     </div>
 </header>
 


### PR DESCRIPTION
## Summary
- rebuild the global header with Preline-style navigation, integrated search controls, and responsive collapse behaviour
- restyle the shared search form and footer layouts to match the new Preline UI aesthetic while preserving Wagtail settings-driven content
- add a lightweight collapse controller and Tailwind plugin variant to support the Preline interaction patterns in the existing build pipeline

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cada98444483339a03b10b2c2c43bd